### PR TITLE
CONTRIBUTING Doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Keep your change as focused as possible. If there are multiple changes you
 would like to make that are not dependent upon each other, consider submitting
 them as separate pull requests.
+- Squash multiple commits into a single, clean commit.
 
 [fork]: https://github.com/opentable/<project>/fork
 [pr]: https://github.com/opentable/<project>/compare

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,6 @@ your patch:
 0. Make your change, add tests, and make sure the tests still pass
 0. Add a CHANGELOG entry detailing your changes
 0. Push to your fork and [submit a pull request][pr]
-0. Accept the [OpenTable CLA][cla]
 0. :beers:
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
@@ -43,7 +42,6 @@ them as separate pull requests.
 
 [fork]: ../../fork
 [pr]: ../../compare
-[cla]: http://link.to.cla.here
 
 ### Style Guide
 > This section should be modified on a per-project basis. Different teams,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ really, thank you.
 
 To get you started, we put together this handy-dandy guide to submitting
 your patch:
+
 0. [Fork][] and clone the repository
 0. Configure and install the dependencies: `script/bootstrap`
 0. Make sure the tests pass on your machine: `script/test`
@@ -41,7 +42,7 @@ them as separate pull requests.
 
 [fork]: https://github.com/opentable/<project>/fork
 [pr]: https://github.com/opentable/<project>/compare
-[cla]: <TODO: Get CLA>
+[cla]: http://link.to.cla.here
 
 ### Style Guide
 TODO: Draft this

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If you want to submit a bug report, [open a new issue][new-issue].
 Please provide a detailed description of the issue and include any relevant
 reproduction steps or stack traces.
 
-[new-issue]: https://github.com/opentable/<project>/issues/new
+[new-issue]: ../../issues/new
 
 ### Submitting Pull Requests
 So you've decided you want to send us some code. That's awesome. No,
@@ -41,15 +41,19 @@ would like to make that are not dependent upon each other, consider submitting
 them as separate pull requests.
 - Squash multiple commits into a single, clean commit.
 
-[fork]: https://github.com/opentable/<project>/fork
-[pr]: https://github.com/opentable/<project>/compare
+[fork]: ../../fork
+[pr]: ../../compare
 [cla]: http://link.to.cla.here
 
 ### Style Guide
-TODO: Draft this
+> This section should be modified on a per-project basis. Different teams,
+> projects, and languages are going to have different style concerns. Your
+> team should complete this section as a part of the OSS release process.
 
 ### Releasing
 This section is for the project's maintainers.
 
-- Use SemVer. Breaking the API in a non-backwards compatible way? Make sure you version it properly. Details at http://semver.org/.
-- Use Git tags for generating new releases. Generally tagging with targeted release version is acceptable.
+- Use SemVer. Breaking the API in a non-backwards compatible way? Make sure
+you version it properly. Details at http://semver.org/.
+- Use Git tags for generating new releases. Generally tagging with the targeted
+release version is acceptable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+Howdy! Thanks for your interest in contributing to this project.
+
+We adhere to the [Open Code of Conduct][code-of-conduct]. By
+participating, you are expected to honor this code.
+
+[code-of-conduct]: http://todogroup.org/opencodeofconduct/#OpenTable/opensource@opentable.com
+
+### Reporting Issues
+If you want to submit a bug report, [open a new issue][new-issue].
+Please provide a detailed description of the issue and include any relevant
+reproduction steps or stack traces.
+
+[new-issue]: https://github.com/opentable/<project>/issues/new
+
+### Submitting Pull Requests
+So you've decided you want to send us some code. That's awesome. No,
+really, thank you.
+
+To get you started, we put together this handy-dandy guide to submitting
+your patch:
+0. [Fork][] and clone the repository
+0. Configure and install the dependencies: `script/bootstrap`
+0. Make sure the tests pass on your machine: `script/test`
+0. Create a new feature branch: `git checkout -b my-awesome-patch`
+0. Make your change, add tests, and make sure the tests still pass
+0. Add a CHANGELOG entry detailing your changes
+0. Push to your fork and [submit a pull request][pr]
+0. Accept the [OpenTable CLA][cla]
+0. :beers:
+
+Here are a few things you can do that will increase the likelihood of your pull request being accepted:
+
+- Follow the style guide (see below) where possible.
+- Write tests.
+- Update documentation as necessary.
+- Keep your change as focused as possible. If there are multiple changes you
+would like to make that are not dependent upon each other, consider submitting
+them as separate pull requests.
+
+[fork]: https://github.com/opentable/<project>/fork
+[pr]: https://github.com/opentable/<project>/compare
+[cla]: <TODO: Get CLA>
+
+### Style Guide
+TODO: Draft this

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,3 +47,9 @@ them as separate pull requests.
 
 ### Style Guide
 TODO: Draft this
+
+### Releasing
+This section is for the project's maintainers.
+
+- Use SemVer. Breaking the API in a non-backwards compatible way? Make sure you version it properly. Details at http://semver.org/.
+- Use Git tags for generating new releases. Generally tagging with targeted release version is acceptable.


### PR DESCRIPTION
This is my first pass at a CONTRIBUTING doc. I took some inspiration from similar documents I've seen in the past. Obviously this won't cover many use cases in its unedited form, but this should provide a decent template for teams to base their own doc on. I'd love any feedback on wording, things I missed, or things we should take out.

Action Items:
- [x] Should we keep the reference to the Open Code of Conduct? This seems like a good middle ground between keeping the code implicit and explicitly embedding another text file in the project.
- [x] Create an opensource@opentable.com mailing list for external OSS queries. We may already have this. (less important if we opt to remove the Open Code of Conduct)
- [x] Determine whether we're going to need a CLA and find a place to host it. If we're not including a CLA, we should remove the reference to it in this document.

cc @opentable/oss 